### PR TITLE
fix allow strings to include escaped characters

### DIFF
--- a/erl_terms/erl_terms_core.py
+++ b/erl_terms/erl_terms_core.py
@@ -44,7 +44,7 @@ def lex(text):
     tuple = ( _ "{" _ term (_ "," _ term)* _ "}" ) / ( _ "{" _ "}")
     map   = ( _ "#{" _ keyvalue (_ "," _ keyvalue)* _ "}" ) / ( _ "#{" _ "}")
     keyvalue = term _ "=>" _ term _
-    string = '"' ~r'(\\\\"|[^\\\\"])*' '"'
+    string = '"' ~r'(\\\\"|[^"])*' '"'
     binary = "<<" string ">>"
     boolean = "true" / "false"
     number = ~"[0-9]+\#[0-9a-zA-Z]+" / ~"[0-9]+(\.[0-9]+)?(e\-?[0-9]+)?"

--- a/erl_terms/tests/test_decode.py
+++ b/erl_terms/tests/test_decode.py
@@ -36,6 +36,7 @@ class DecodeEverythingTests(TestCase):
     def test_string(self):
         eq_(decode('"ohai".'), [('ohai')])
         eq_(decode(r'"password:\"123\"".'), [('password:"123"')])
+        eq_(decode('"ascii code \e[1;34m".'), [('ascii code \e[1;34m')])
 
     def test_map(self):
         eq_(decode('#{}.'), [{}])


### PR DESCRIPTION
parser string regex is too restrictive and is rejecting escaped characters others than double-quotes
