### PR TITLE
Explicitly import reduce from functools

### DIFF
--- a/erl_terms/erl_terms_core.py
+++ b/erl_terms/erl_terms_core.py
@@ -1,6 +1,7 @@
 import re
 from parsimonious.grammar import Grammar
 import parsimonious.exceptions
+from functools import reduce
 
 class ParseError(Exception):
     pass


### PR DESCRIPTION
This minor change is intended to make library run error free in Python 3.

Python 3 dropped support for reduce() without using functools. 

Reduce() is available in functools in Python2 as well. 
https://docs.python.org/2/library/functools.html#functools.reduce 

"This is the same function as reduce(). It is made available in this module to allow writing code more forward-compatible with Python 3."

Lack of this will throw an error in Python 3 : NameError: name 'reduce' is not defined