### PR TITLE
removed argument no longer valid in setuptools >=58

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,4 @@ setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Text Processing :: General'],
     keywords=['parse', 'parser', 'erlang', 'peg', 'grammar', 'language'],
-    use_2to3=version_info >= (3,)
 )


### PR DESCRIPTION
This PR makes `setup.py` valid in environments with setuptools >= v58